### PR TITLE
Fixed normal calculations for clouds that are far away from the origin.

### DIFF
--- a/src/GeoDetection.cpp
+++ b/src/GeoDetection.cpp
@@ -124,9 +124,11 @@ namespace GeoDetection
 		return resolution;
 	}
 
-	pcl::PointCloud<pcl::Normal>::Ptr 
+	 pcl::PointCloud<pcl::Normal>::Ptr 
 		Cloud::getNormalsRadiusSearch(float radius)
 	{
+		GD_CORE_ERROR("ERROR: This method will produce unreliable normals, if neighborhoods are far away from the origin.\
+					Ongoing fix... Use getNormalsRadiusSearchDemeaned instead for now...");
 		GD_CORE_TRACE(":: Computing point cloud normals...\n:: Normal scale {0}", radius);
 		GD_CORE_WARN(":: # Threads automatically set to the number of cores: {0}",
 			omp_get_num_procs());
@@ -149,9 +151,61 @@ namespace GeoDetection
 		return normals;
 	}
 
+	 pcl::PointCloud<pcl::Normal>::Ptr
+		 Cloud::getNormalsRadiusSearchDemeaned(float radius)
+	 {
+		 pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
+		 normals->resize(m_cloud->size());
+		 //compute3DCentroid(*cloud_in, centroid);
+
+		 // Iterate through each point and compute normals from demeaned neighborhoods.
+#pragma omp parallel for
+		 for (int i = 0; i < m_cloud->size(); i++)
+		 {
+			 //Create local variables
+			 pcl::PointCloud<pcl::PointXYZ> cloud_demeaned;  // tmp cloud for demeaning
+
+			 std::vector<int> indices;
+			 std::vector<float> sqdistances;
+
+			 //Get neighborhood and copy it into the new temp cloud (0th index corresponds to i)
+			 m_kdtree->radiusSearch(m_cloud->points[i], radius, indices, sqdistances);
+			 cloud_demeaned.reserve(indices.size());
+
+			 for (int j = 0; j < indices.size(); j++)
+			 {
+				 cloud_demeaned.push_back(m_cloud->points[indices[j]]);
+			 }
+
+			 // De-mean the whole tmp cloud by point i's coordinates to center it on 0,0,0
+			 Eigen::Affine3d transform = Eigen::Affine3d::Identity();
+			 transform.translation() << -m_cloud->points[i].x, -m_cloud->points[i].y, -m_cloud->points[i].z;
+			 pcl::transformPointCloud(cloud_demeaned, cloud_demeaned, transform);
+
+			 // Compute the point normal
+			 float curvature;
+			 Eigen::Vector4f n;
+			 pcl::computePointNormal(cloud_demeaned, n, curvature);
+
+			 // Flip normals so they consistently point in one direction (towards centroid)
+			 pcl::flipNormalTowardsViewpoint(m_cloud->points[i], m_view[0], m_view[1], m_view[2], n);
+
+			 // Set the normal to the result
+			 pcl::Normal& pnormal = normals->points[i];
+			 pnormal.normal_x = n[0];
+			 pnormal.normal_y = n[1];
+			 pnormal.normal_z = n[2];
+			 pnormal.curvature = curvature;
+		 }
+
+		 return normals;
+	 }
+
 	pcl::PointCloud<pcl::Normal>::Ptr
 		Cloud::getNormalsKSearch(int k)
 	{
+		GD_CORE_ERROR("ERROR: This method will produce unreliable normals, if neighborhoods are far away from the origin.\
+					Ongoing fix... Use getNormalsKSearchDemeaned instead for now...");
 		GD_CORE_TRACE(":: Computing point cloud normals...\n:: Number of neighbors: {0}", k);
 		GD_CORE_WARN(":: # Threads automatically set to the number of cores: {0}",
 			omp_get_num_procs());
@@ -171,6 +225,55 @@ namespace GeoDetection
 
 		GD_CORE_WARN("--> Normal calculation time: {0} ms\n",
 			GeoDetection::Time::getDuration(start));
+
+		return normals;
+	}
+
+	pcl::PointCloud<pcl::Normal>::Ptr
+		Cloud::getNormalsKSearchDemeaned(int k)
+	{
+		pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
+		normals->resize(m_cloud->size());
+		//compute3DCentroid(*cloud_in, centroid);
+
+		// Iterate through each point and compute normals from demeaned neighborhoods.
+#pragma omp parallel for
+		for (int i = 0; i < m_cloud->points.size(); i++)
+		{
+			//Create local variables
+			pcl::PointCloud<pcl::PointXYZ> cloud_demeaned(k, 1);  // cloud for local demaned neighborhood
+
+			std::vector<int> indices(k);
+			std::vector<float> sqdistances(k);
+
+			//Get neighborhood and copy it into the new temp cloud (0th index corresponds to i)
+			m_kdtree->nearestKSearch(m_cloud->points[i], k, indices, sqdistances);
+
+			for (int j = 0; j < indices.size(); j++)
+			{
+				cloud_demeaned.push_back(m_cloud->points[indices[j]]);
+			}
+
+			// De-mean the whole tmp cloud by point i's coordinates to center it on 0,0,0
+			Eigen::Affine3d transform = Eigen::Affine3d::Identity();
+			transform.translation() << -m_cloud->points[i].x, -m_cloud->points[i].y, -m_cloud->points[i].z;
+			pcl::transformPointCloud(cloud_demeaned, cloud_demeaned, transform);
+
+			// Compute the point normal
+			float curvature;
+			Eigen::Vector4f n;
+			pcl::computePointNormal(cloud_demeaned, n, curvature);
+
+			// Flip normals so they consistently point in one direction (towards centroid)
+			pcl::flipNormalTowardsViewpoint(m_cloud->points[i], m_view[0], m_view[1], m_view[2], n);
+
+			// Set the normal to the result
+			pcl::Normal& pnormal = normals->points[i];
+			pnormal.normal_x = n[0];
+			pnormal.normal_y = n[1];
+			pnormal.normal_z = n[2];
+			pnormal.curvature = curvature;
+		}
 
 		return normals;
 	}

--- a/src/GeoDetection.h
+++ b/src/GeoDetection.h
@@ -158,11 +158,44 @@ namespace GeoDetection
 		*/
 		pcl::PointCloud<pcl::Normal>::Ptr getNormalsRadiusSearch(float radius);
 
+		/** \brief Method for computing normals, for neighborhoods that are far away from the origin. 
+		* \View point is set as 0,0,0 as default unless set with setView
+		* \param[in] radius: Radius for spherical neighbour search used for principle component analysis.
+		* \return shared pointer to the computed normals.
+		*/
+		pcl::PointCloud<pcl::Normal>::Ptr getNormalsRadiusSearchDemeaned(float radius);
+
 		/** \brief Method for computing normals. View point is set as 0,0,0 as default unless set with setView
 		* \param[in] k: # neighbors to use for normal estimation
 		* \return shared pointer to the computed normals.
 		*/
 		pcl::PointCloud<pcl::Normal>::Ptr getNormalsKSearch(int k);
+
+		/** \brief Method for computing normals, for neighborhoods that are far away from the origin.
+		* \View point is set as 0,0,0 as default unless set with setView
+		* \param[in] radius: Radius for spherical neighbour search used for principle component analysis.
+		* \return shared pointer to the computed normals.
+		*/
+		pcl::PointCloud<pcl::Normal>::Ptr getNormalsKSearchDemeaned(int k);
+
+		/** \calls getNormalsRadiusSearch and sets member normals to the result.
+		* \param[in] radius: Radius for spherical neighbour search used for principle component analysis.
+		*/
+		inline void updateNormalsRadiusSearch(float radius) 
+		{
+			auto new_normals = this->getNormalsRadiusSearch(radius); 
+			this->setNormals(new_normals);
+		}
+
+		/** \calls getNormalsKSearch and sets member normals to the result.
+		* \param[in] k: # neighbors to use for normal estimation
+		*/
+		inline void updateNormalsRadiusSearch(int k)
+		{
+			auto new_normals = this->getNormalsKSearch(k);
+			this->setNormals(new_normals);
+		}
+
 
 		/** \brief Method for averaging normals within a defined search radius, at select subset of corepoints */
 		void averageNormalsSubset(float radius, pcl::PointCloud<pcl::PointXYZ>::Ptr corepoints);

--- a/src/features.cpp
+++ b/src/features.cpp
@@ -1,6 +1,8 @@
 #include "features.h"
 #include "core.h"
 
+#include <pcl/features/normal_3d.h>
+
 namespace GeoDetection
 {
 //HELPERS
@@ -16,6 +18,30 @@ namespace GeoDetection
 		return average;
 	}
 
+//NORMALS-ORIENTING
+
+//	void 
+//		orientNormalsWithViewpoint(pcl::PointCloud<pcl::PointXYZ> cloud, pcl::PointCloud<pcl::Normal> normals_in, 
+//			pcl::PointCloud<pcl::Normal> normals_out, float vp_x, float vp_y, float vp_z)
+//	{
+//		if (cloud.size() != normals_in.size())
+//		{
+//			GD_CORE_ERROR("Cannot flip normals that do not share the same dimensions: {0} as the cloud: {1}",
+//				normals_in.size(), cloud.size());
+//		}
+//
+//		if (&normals_in != &normals_out)
+//		{
+//			pcl::copyPointCloud(normals_in, normals_out);
+//		}
+//
+//#pragma omp parallel for
+//		for (int64_t i = 0; i < normals_in.size(); i++)
+//		{
+//			pcl::Normal& n = normals_out[i];
+//			pcl::flipNormalTowardsViewpoint(cloud[i], vp_x, vp_y, vp_z, n.normal_x, n.normal_y, n.normal_z);
+//		}
+//	}
 //FEATURE-AVERAGING
 
 	pcl::PointCloud<pcl::Normal>::Ptr


### PR DESCRIPTION
Catastrophic cancellation occurs during the covariance computations
(uses float for arithmetic).

New `getNormalsKSearchDemeaned` and `getNormalsRadiusSearchDemeaned` move
neighborhoods to the origin before computing covariance matrix for
normal calculations.